### PR TITLE
Update error_handler.js

### DIFF
--- a/lib/middleware/error_handler.js
+++ b/lib/middleware/error_handler.js
@@ -1,29 +1,24 @@
-/* jshint ignore:start */
 var Messages = require("../constants/messages");
 
-function getFailedResponse(err){
-    
+function getFailedResponse(err) {
     var error_message;
-    var http_code = err.httpCode ? err.httpCode : 500;
-    
-    if(http_code === 500){
-        if(global.showExceptionToClient){
-            error_message = err.error_message ? err.error_message : err;
-        }
-        else{
+    var http_code = err.httpCode || err.status || 500;
+
+    if (http_code === 500) {
+        if (global.showExceptionToClient) {
+            error_message = err.error_message || err.message || err;
+        } else {
             error_message = Messages.INTERNAL_ERROR;
         }
+    } else {
+        error_message = err.error_message || err.message;
     }
-    else{
-        error_message = err.error_message;
-    }
-    
-    if(error_message.constructor.toString().indexOf("Array") === -1){
+    if (error_message.constructor.toString().indexOf("Array") === -1) {
         var temp_message = error_message;
         error_message = [];
         error_message.push(temp_message);
     }
-    
+
     return {
         meta: {
             code: http_code,
@@ -32,17 +27,10 @@ function getFailedResponse(err){
     };
 }
 
-function errorHandler(err, req, res, next) {
-    
+module.exports = function errorHandler(err, req, res, next) {
     var failed_response = getFailedResponse(err);
-    res.send( failed_response.meta.code , failed_response );
-    if(failed_response.meta.code === 500)
+    res.send(failed_response.meta.code, failed_response);
+    if (failed_response.meta.code === 500) {
         global.Logger.error(err);
-    return;
+    }
 }
-
-/* jshint ignore:end */
-
-/* jshint ignore:start */
-module.exports = errorHandler;
-/* jshint ignore:end */


### PR DESCRIPTION
add err.message support.

It will help get errors, like:
```
{
	"meta": {
		"code": 400,
		"message": [
			"invalid json"
		]
	}
}
```